### PR TITLE
Document per-issue demo script in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,96 @@ tests/
   login.spec.ts        # currently flaky — see issue #2
 ```
 
-## Open work
-See the [issues list](../../issues) — five curated tasks covering UI, tests,
-security, docs and refactors.
+## Demo script — showcasing the GitHub App
+
+Five issues are pre-filed, each chosen to highlight a specific capability of
+the GitHub App. Run them in this order for the cleanest narrative, or cherry
+pick whichever beat you need.
+
+The "hero flow" used in the launch video is **Issue #1**. The other four are
+staged as background context: one mid-flight, one in Plan mode, one in
+Interactive mode, and one as an open PR ready to merge — so the Inbox looks
+alive when the camera opens.
+
+### Issue #1 — Add dark mode toggle to the app header
+**Showcases:** Issue → session → diff → PR → merge, all in one surface.
+**Mode:** Autopilot.
+
+1. From the Inbox, click issue #1 and choose **Start session**.
+2. Note the auto-generated branch (`add-dark-mode-toggle`) and isolated workspace.
+3. Pick **Autopilot** and let it run. It should edit `public/styles.css`,
+   add a `ThemeToggle` to each HTML page, and persist the choice in
+   `localStorage`.
+4. Open the **Diff** tab and scroll through the changes.
+5. In the live preview, click the toggle — the app flips from light to dark.
+   This is the money shot.
+6. Click **Create pull request**, wait for checks, then **Merge**.
+7. Back in the Inbox, issue #1 now shows as Closed.
+
+### Issue #2 — Fix flaky login test in CI
+**Showcases:** Plan mode, transparent reasoning before execution.
+**Mode:** Plan.
+
+1. Open issue #2 → **Start session** → **Plan**.
+2. Let the agent produce its plan. It should identify the
+   `setTimeout` race in `tests/login.spec.ts` and propose awaiting the
+   response instead.
+3. Review the plan on camera — this is the moment that proves the agent
+   shows its work before touching code.
+4. Approve the plan. The agent rewrites the test; `npm test` stays green
+   without any arbitrary waits.
+
+### Issue #3 — Add rate limiting middleware to the public API
+**Showcases:** Real multi-file diffs, clean backend changes.
+**Mode:** Autopilot.
+
+1. Open issue #3 → **Start session** → **Autopilot**.
+2. The agent creates `src/middleware/rateLimit.ts`, wires it into
+   `src/server.ts`, adds per-route overrides, and writes unit tests.
+3. Use this session as your "mid-flight" tile in the parallel-sessions
+   scene — pause it while files are still changing for the best visual.
+
+### Issue #4 — Generate OpenAPI spec from route definitions
+**Showcases:** Docs + tooling work, PR lifecycle with green checks.
+**Mode:** Autopilot.
+
+1. Open issue #4 → **Start session** → **Autopilot**.
+2. The agent adds `npm run docs:api`, generates `openapi.json` from the
+   zod schemas already exported next to each route, and serves Swagger UI
+   at `/docs` in development.
+3. Let it open a pull request but **do not merge it yet** — park it in
+   the "ready to merge, all checks green" state so you can show the PR
+   surface without spending a live merge on it.
+
+### Issue #5 — Refactor UserService to use dependency injection
+**Showcases:** Interactive collaboration, human-in-the-loop control.
+**Mode:** Interactive.
+
+1. Open issue #5 → **Start session** → **Interactive**.
+2. Send one message: "Start with the constructor signature."
+3. Let the agent reply with a clarifying question (for example, whether
+   to introduce an interface or keep concrete types).
+4. Leave the session paused on that question — it's your "waiting on
+   you" tile in the parallel-sessions scene.
+
+### Staging summary for the Inbox shot
+
+| Issue | State when you hit record          | Purpose                          |
+|-------|------------------------------------|----------------------------------|
+| #1    | Fresh, untouched                   | Hero flow                        |
+| #2    | Plan mode, paused on plan          | Plan mode tile                   |
+| #3    | Autopilot, ~60% through            | Mid-flight tile                  |
+| #4    | PR open, green checks              | Lifecycle / merge-ready tile     |
+| #5    | Interactive, waiting on user       | Human-in-the-loop tile           |
+
+### Tips
+
+- Set the GitHub App's own theme to light before recording so the Scene 5
+  light-to-dark flip reads clearly.
+- Close every other repo in the sidebar. Only `github-app-demo` should be
+  visible.
+- Pre-record the agent-working scene at real speed and speed-ramp it in
+  post. Do not try to capture 30 seconds of live tool calls on the first
+  take.
+
+See the [issues list](../../issues) for the full specs on each task.


### PR DESCRIPTION
The repo is the hero codebase for the GitHub App launch video, but until now there was no written record of how to actually drive the demo. This adds that runbook directly to the README so anyone presenting the app can reproduce the shot list without guessing.

## What's in it

- A new **Demo script** section with one subsection per issue (#1-#5).
- For each issue: what capability it showcases, which session mode to use, and the click-by-click steps the presenter follows.
- Issue #1 is flagged as the hero end-to-end flow. Issues #2-#5 are described as staging tiles (Plan paused, Autopilot mid-flight, PR ready to merge, Interactive waiting on user).
- A staging summary table so the Inbox is in the right state before recording.
- Recording tips (light theme baseline, close other repos, speed-ramp the agent-working scene).

Docs-only change. No code touched.