### PR TITLE
Generate OpenAPI spec from route definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ agentic development demo.
 npm install
 npm run dev    # http://localhost:3000
 npm test
+npm run docs:api   # regenerate openapi.json from the zod schemas
 ```
 
 Sign in with `ada@example.com` / `password`.
+
+API docs are served at [http://localhost:3000/docs](http://localhost:3000/docs)
+when the dev server is running.
 
 ## Layout
 

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,206 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "github-app-demo API",
+    "version": "0.1.0",
+    "description": "Auto-generated from route-level zod schemas."
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3000",
+      "description": "Local dev"
+    }
+  ],
+  "paths": {
+    "/api/health": {
+      "get": {
+        "summary": "Health check",
+        "responses": {
+          "200": {
+            "description": "Service healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/auth/login": {
+      "post": {
+        "summary": "Authenticate a user",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email"
+                  },
+                  "password": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "required": [
+                  "email",
+                  "password"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "token": {
+                      "type": "string"
+                    },
+                    "user": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "email": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "email",
+                        "name"
+                      ],
+                      "additionalProperties": false
+                    }
+                  },
+                  "required": [
+                    "token",
+                    "user"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body"
+          },
+          "401": {
+            "description": "Invalid credentials"
+          }
+        }
+      }
+    },
+    "/api/users": {
+      "get": {
+        "summary": "List users",
+        "responses": {
+          "200": {
+            "description": "User list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string"
+                      },
+                      "email": {
+                        "type": "string",
+                        "format": "email"
+                      },
+                      "name": {
+                        "type": "string"
+                      }
+                    },
+                    "required": [
+                      "id",
+                      "email",
+                      "name"
+                    ],
+                    "additionalProperties": false
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/users/{id}": {
+      "get": {
+        "summary": "Get a single user",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "email": {
+                      "type": "string",
+                      "format": "email"
+                    },
+                    "name": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "email",
+                    "name"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,16 @@
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.19.2",
-        "zod": "^3.23.8"
+        "swagger-ui-express": "^5.0.1",
+        "zod": "^3.23.8",
+        "zod-to-json-schema": "^3.23.1"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/node": "^20.14.0",
         "@types/supertest": "^6.0.2",
+        "@types/swagger-ui-express": "^4.1.6",
         "supertest": "^7.0.0",
         "tsx": "^4.15.0",
         "typescript": "^5.4.5",
@@ -897,6 +900,13 @@
         "win32"
       ]
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
@@ -1075,6 +1085,17 @@
       "dependencies": {
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
       }
     },
     "node_modules/@vitest/expect": {
@@ -2882,6 +2903,30 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.4.tgz",
+      "integrity": "sha512-0AADFFQNJzExEN49SrD/34Nn9cxNxVLiydYl2MBwSZFPVXNkVwC/EFAjoezGGqE8oDegiDC+p47t8lKObCinMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3705,6 +3750,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,18 +10,23 @@
     "build": "tsc",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "docs:api": "tsx scripts/generate-openapi.ts",
+    "docs:api:check": "tsx scripts/generate-openapi.ts --check"
   },
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.19.2",
-    "zod": "^3.23.8"
+    "swagger-ui-express": "^5.0.1",
+    "zod": "^3.23.8",
+    "zod-to-json-schema": "^3.23.1"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/node": "^20.14.0",
     "@types/supertest": "^6.0.2",
+    "@types/swagger-ui-express": "^4.1.6",
     "supertest": "^7.0.0",
     "tsx": "^4.15.0",
     "typescript": "^5.4.5",

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -1,0 +1,26 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { openApiSpec } from '../src/openapi.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const outFile = path.resolve(__dirname, '..', 'openapi.json');
+
+const serialized = JSON.stringify(openApiSpec, null, 2) + '\n';
+const isCheck = process.argv.includes('--check');
+
+if (isCheck) {
+  if (!fs.existsSync(outFile)) {
+    console.error('openapi.json is missing. Run `npm run docs:api`.');
+    process.exit(1);
+  }
+  const current = fs.readFileSync(outFile, 'utf8');
+  if (current !== serialized) {
+    console.error('openapi.json is out of date. Run `npm run docs:api`.');
+    process.exit(1);
+  }
+  console.log('openapi.json is up to date.');
+} else {
+  fs.writeFileSync(outFile, serialized);
+  console.log(`Wrote ${path.relative(process.cwd(), outFile)}`);
+}

--- a/src/openapi.ts
+++ b/src/openapi.ts
@@ -1,0 +1,98 @@
+import { zodToJsonSchema } from 'zod-to-json-schema';
+import { loginSchema, loginResponseSchema } from '../src/routes/auth.js';
+import { userSchema, userListSchema } from '../src/routes/users.js';
+
+export const openApiSpec = {
+  openapi: '3.1.0',
+  info: {
+    title: 'github-app-demo API',
+    version: '0.1.0',
+    description: 'Auto-generated from route-level zod schemas.',
+  },
+  servers: [{ url: 'http://localhost:3000', description: 'Local dev' }],
+  paths: {
+    '/api/health': {
+      get: {
+        summary: 'Health check',
+        responses: {
+          '200': {
+            description: 'Service healthy',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: { status: { type: 'string', example: 'ok' } },
+                  required: ['status'],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/auth/login': {
+      post: {
+        summary: 'Authenticate a user',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: zodToJsonSchema(loginSchema, { target: 'openApi3' }),
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'Authenticated',
+            content: {
+              'application/json': {
+                schema: zodToJsonSchema(loginResponseSchema, { target: 'openApi3' }),
+              },
+            },
+          },
+          '400': { description: 'Invalid request body' },
+          '401': { description: 'Invalid credentials' },
+        },
+      },
+    },
+    '/api/users': {
+      get: {
+        summary: 'List users',
+        responses: {
+          '200': {
+            description: 'User list',
+            content: {
+              'application/json': {
+                schema: zodToJsonSchema(userListSchema, { target: 'openApi3' }),
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/users/{id}': {
+      get: {
+        summary: 'Get a single user',
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' },
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'User found',
+            content: {
+              'application/json': {
+                schema: zodToJsonSchema(userSchema, { target: 'openApi3' }),
+              },
+            },
+          },
+          '404': { description: 'User not found' },
+        },
+      },
+    },
+  },
+} as const;

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,8 +2,10 @@ import express from 'express';
 import cors from 'cors';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import swaggerUi from 'swagger-ui-express';
 import { authRouter } from './routes/auth.js';
 import { usersRouter } from './routes/users.js';
+import { openApiSpec } from './openapi.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -18,6 +20,11 @@ export function createApp() {
   app.get('/api/health', (_req, res) => {
     res.json({ status: 'ok' });
   });
+
+  app.get('/openapi.json', (_req, res) => {
+    res.json(openApiSpec);
+  });
+  app.use('/docs', swaggerUi.serve, swaggerUi.setup(openApiSpec as never));
 
   const publicDir = path.resolve(__dirname, '../public');
   app.use(express.static(publicDir));


### PR DESCRIPTION
Closes #4.

Docs for this API were drifting from the code. This generates an OpenAPI 3.1 spec directly from the zod schemas already exported next to each route, and serves Swagger UI so reviewers can try endpoints during local dev.

## Approach

- `src/openapi.ts` describes the four routes (`/api/health`, `/api/auth/login`, `/api/users`, `/api/users/:id`) and converts the existing zod schemas to JSON Schema with `zod-to-json-schema`. No new hand-written schemas.
- `scripts/generate-openapi.ts` writes `openapi.json` from that module.
- `src/server.ts` mounts the spec at `/openapi.json` and Swagger UI at `/docs`.
- New npm scripts: `docs:api` (regenerate) and `docs:api:check` (drift guard for CI).

## Verified

- `npm run docs:api` writes a clean `openapi.json`
- `npm run lint` (tsc --noEmit) passes
- `npm test` passes (2/2)
- `GET /openapi.json` returns 200 with the spec
- `GET /docs` serves Swagger UI

## Notes for reviewers

- The spec is committed so the drift check has something to compare against; regenerate whenever you touch a route.
- Out of scope (per the issue): publishing to an external portal.