### PR TITLE
Name the product 'Flight Deck' in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # github-app-demo
 
 A tiny Express + TypeScript app used as a sample codebase for demonstrating
-the GitHub App.
+Flight Deck.
 
 ## Stack
 - Node.js 20+
@@ -45,7 +45,7 @@ tests/
 ## Demo guide
 
 Five issues are pre-filed, each chosen to highlight a specific capability of
-the GitHub App. They can be walked through in order for a full end-to-end
+Flight Deck. They can be walked through in order for a full end-to-end
 story, or used individually to demonstrate a single capability.
 
 Issue #1 is the suggested end-to-end flow (issue -> session -> diff -> PR ->
@@ -138,7 +138,7 @@ Staging tip: leave the session paused on that question to use it as a
 
 ### Tips
 
-- Set the GitHub App to the light theme first so the dark-mode toggle in
+- Set Flight Deck to the light theme first so the dark-mode toggle in
   issue #1 reads clearly.
 - Close unrelated repositories in the sidebar so the Inbox focuses on this
   repo.
@@ -146,3 +146,5 @@ Staging tip: leave the session paused on that question to use it as a
   follow when presenting.
 
 See the [issues list](../../issues) for the full specs on each task.
+
+

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "description": "Small Express + TS app used as the hero codebase for the GitHub App demo.",
+  "description": "Small Express + TS app used as the sample codebase for the Flight Deck demo.",
   "scripts": {
     "dev": "tsx watch src/server.ts",
     "start": "tsx src/server.ts",
@@ -28,3 +28,5 @@
     "vitest": "^1.6.0"
   }
 }
+
+


### PR DESCRIPTION
The product being demoed does not have a finalized name. This assigns a short codename — **Flight Deck** — so the docs read naturally instead of repeatedly saying `the GitHub App` or `the app`.

## Why `Flight Deck`
- Matches the positioning: one surface for directing multiple agents and landing their work.
- Short and reads well both as a proper noun (`in Flight Deck`) and with an article (`Set Flight Deck to the light theme`).
- No known collision with existing Microsoft / GitHub product names.

## Changes
- README: three references swapped from `the GitHub App` to `Flight Deck`.
- package.json: description updated.

If the real name lands later, it is a simple find-and-replace.
