### PR TITLE
Add dark mode toggle to the app header

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,3 +1,13 @@
+const themeButtons = document.querySelectorAll('[data-theme-toggle]');
+themeButtons.forEach((btn) => {
+  btn.addEventListener('click', () => {
+    const current = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+    const next = current === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    try { localStorage.setItem('theme', next); } catch (_) { /* ignore */ }
+  });
+});
+
 const form = document.getElementById('login-form');
 if (form) {
   form.addEventListener('submit', async (e) => {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Dashboard — Demo App</title>
+    <script src="/theme-init.js"></script>
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
@@ -12,6 +13,10 @@
       <nav>
         <a href="/">Home</a>
         <a href="/login.html">Sign out</a>
+        <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle theme">
+          <span class="icon-light" aria-hidden="true">🌙</span>
+          <span class="icon-dark" aria-hidden="true">☀️</span>
+        </button>
       </nav>
     </header>
 

--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Demo App</title>
+    <script src="/theme-init.js"></script>
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
@@ -12,6 +13,10 @@
       <nav>
         <a href="/">Home</a>
         <a href="/login.html">Sign in</a>
+        <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle theme">
+          <span class="icon-light" aria-hidden="true">🌙</span>
+          <span class="icon-dark" aria-hidden="true">☀️</span>
+        </button>
       </nav>
     </header>
 

--- a/public/login.html
+++ b/public/login.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Sign in — Demo App</title>
+    <script src="/theme-init.js"></script>
     <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
@@ -11,6 +12,10 @@
       <div class="brand">Demo App</div>
       <nav>
         <a href="/">Home</a>
+        <button type="button" class="theme-toggle" data-theme-toggle aria-label="Toggle theme">
+          <span class="icon-light" aria-hidden="true">🌙</span>
+          <span class="icon-dark" aria-hidden="true">☀️</span>
+        </button>
       </nav>
     </header>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -7,6 +7,15 @@
   --accent: #0969da;
 }
 
+:root[data-theme='dark'] {
+  --bg: #0d1117;
+  --fg: #e6edf3;
+  --muted: #8b949e;
+  --surface: #161b22;
+  --border: #30363d;
+  --accent: #2f81f7;
+}
+
 * { box-sizing: border-box; }
 
 html, body {
@@ -29,11 +38,36 @@ html, body {
 }
 
 .app-header .brand { font-weight: 600; }
+.app-header nav {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
 .app-header nav a {
-  margin-left: 16px;
   color: var(--accent);
   text-decoration: none;
 }
+
+.theme-toggle {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--fg);
+  width: 36px;
+  height: 32px;
+  border-radius: 6px;
+  padding: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  line-height: 1;
+}
+.theme-toggle:hover { background: var(--surface); }
+.theme-toggle .icon-dark { display: none; }
+:root[data-theme='dark'] .theme-toggle .icon-light { display: none; }
+:root[data-theme='dark'] .theme-toggle .icon-dark { display: inline; }
 
 .container {
   max-width: 720px;

--- a/public/theme-init.js
+++ b/public/theme-init.js
@@ -1,0 +1,7 @@
+(function () {
+  var stored = null;
+  try { stored = localStorage.getItem('theme'); } catch (_) { /* ignore */ }
+  var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+  var theme = stored || (prefersDark ? 'dark' : 'light');
+  document.documentElement.setAttribute('data-theme', theme);
+})();


### PR DESCRIPTION
Closes #1.

Adds a theme toggle to the app header that flips between light and dark, persists the choice, respects `prefers-color-scheme` on first visit, and avoids a flash of unstyled content.

## Approach
- All three pages share a `.app-header` so the toggle only needs to be added once per file.
- Dark theme is driven by `:root[data-theme='dark']` overriding the same CSS variables the light theme uses. Nothing hard-codes a colour, so future themes are cheap to add.
- `public/theme-init.js` is a tiny inline-style script loaded in `<head>` that sets `data-theme` before stylesheets paint. This is what prevents FOUC.
- The toggle handler in `app.js` flips `data-theme` on `<html>` and writes to `localStorage.theme`.

## Acceptance criteria
- [x] Toggle button visible in the header on every page
- [x] Instant switch between light and dark
- [x] Persists via `localStorage`
- [x] Respects `prefers-color-scheme` on first visit
- [x] No flash of unstyled content on load
- [x] Colour tokens are centralized

## Verified
- `npm run lint` clean
- `npm test` 2/2
