### PR TITLE
Add rate limiting middleware

### DIFF
--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -1,0 +1,50 @@
+import type { Request, Response, NextFunction } from 'express';
+
+export interface RateLimitOptions {
+  windowMs?: number;
+  max?: number;
+  keyGenerator?: (req: Request) => string;
+}
+
+interface Bucket {
+  count: number;
+  resetAt: number;
+}
+
+export function rateLimit(options: RateLimitOptions = {}) {
+  const windowMs = options.windowMs ?? 60_000;
+  const max = options.max ?? 100;
+  const keyGenerator = options.keyGenerator ?? ((req) => req.ip ?? 'unknown');
+
+  const buckets = new Map<string, Bucket>();
+
+  return function rateLimitMiddleware(req: Request, res: Response, next: NextFunction) {
+    const key = keyGenerator(req);
+    const now = Date.now();
+    let bucket = buckets.get(key);
+
+    if (!bucket || bucket.resetAt <= now) {
+      bucket = { count: 0, resetAt: now + windowMs };
+      buckets.set(key, bucket);
+    }
+
+    bucket.count += 1;
+
+    const remaining = Math.max(0, max - bucket.count);
+    res.setHeader('X-RateLimit-Limit', String(max));
+    res.setHeader('X-RateLimit-Remaining', String(remaining));
+    res.setHeader('X-RateLimit-Reset', String(Math.ceil(bucket.resetAt / 1000)));
+
+    if (bucket.count > max) {
+      const retryAfterSec = Math.max(1, Math.ceil((bucket.resetAt - now) / 1000));
+      res.setHeader('Retry-After', String(retryAfterSec));
+      res.status(429).json({
+        error: 'Too Many Requests',
+        message: `Rate limit exceeded. Retry after ${retryAfterSec}s.`,
+      });
+      return;
+    }
+
+    next();
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { authRouter } from './routes/auth.js';
 import { usersRouter } from './routes/users.js';
+import { rateLimit } from './middleware/rateLimit.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -12,7 +13,11 @@ export function createApp() {
   app.use(cors());
   app.use(express.json());
 
-  app.use('/api/auth', authRouter);
+  // Global API rate limit: 100 requests / minute / IP.
+  app.use('/api', rateLimit({ windowMs: 60_000, max: 100 }));
+
+  // Stricter limit on auth endpoints to slow down credential-stuffing.
+  app.use('/api/auth', rateLimit({ windowMs: 60_000, max: 10 }), authRouter);
   app.use('/api/users', usersRouter);
 
   app.get('/api/health', (_req, res) => {

--- a/tests/rateLimit.spec.ts
+++ b/tests/rateLimit.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { rateLimit } from '../src/middleware/rateLimit.js';
+
+function buildApp(max: number, windowMs = 60_000) {
+  const app = express();
+  app.use(rateLimit({ max, windowMs }));
+  app.get('/ping', (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+describe('rateLimit middleware', () => {
+  it('allows requests under the limit', async () => {
+    const app = buildApp(3);
+    for (let i = 0; i < 3; i++) {
+      const res = await request(app).get('/ping');
+      expect(res.status).toBe(200);
+    }
+  });
+
+  it('returns 429 with Retry-After once the limit is exceeded', async () => {
+    const app = buildApp(2);
+    await request(app).get('/ping');
+    await request(app).get('/ping');
+    const res = await request(app).get('/ping');
+    expect(res.status).toBe(429);
+    expect(res.body.error).toBe('Too Many Requests');
+    expect(res.headers['retry-after']).toBeDefined();
+    expect(Number(res.headers['retry-after'])).toBeGreaterThan(0);
+  });
+
+  it('advertises limit and remaining counts via headers', async () => {
+    const app = buildApp(5);
+    const res = await request(app).get('/ping');
+    expect(res.headers['x-ratelimit-limit']).toBe('5');
+    expect(res.headers['x-ratelimit-remaining']).toBe('4');
+  });
+
+  it('resets after the window elapses', async () => {
+    const app = buildApp(1, 50);
+    await request(app).get('/ping');
+    const blocked = await request(app).get('/ping');
+    expect(blocked.status).toBe(429);
+    await new Promise((r) => setTimeout(r, 60));
+    const res = await request(app).get('/ping');
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
Closes #3.

## What
Adds an in-process rate limiter mounted on `/api` (100 req/min) with a stricter override on `/api/auth` (10 req/min) to slow credential stuffing.

## Design
- `src/middleware/rateLimit.ts` exports a `rateLimit({ windowMs, max, keyGenerator })` factory. The returned middleware uses a fixed-window counter keyed by IP (overridable).
- Every response gets `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`.
- Over-limit responses return `429 Too Many Requests` with a `Retry-After` header.
- Per-route overrides work by mounting the factory again at a subpath — demonstrated on `/api/auth`.

## Scope note
In-process state is fine for this demo app. A production deployment on multiple replicas would swap the `Map` for a shared store (Redis) behind the same factory.

## Verified
- `npm run lint` clean
- `npm test` 6/6 (2 existing + 4 new)
