### PR TITLE
Refactor UserService to use dependency injection

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { z } from 'zod';
-import { UserService } from '../services/UserService.js';
+import { getDefaultUserService } from '../services/UserService.js';
 
 export const loginSchema = z.object({
   email: z.string().email(),
@@ -18,7 +18,7 @@ export const loginResponseSchema = z.object({
 
 export const authRouter = Router();
 
-const users = new UserService();
+const users = getDefaultUserService();
 
 authRouter.post('/login', async (req, res) => {
   const parsed = loginSchema.safeParse(req.body);

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { z } from 'zod';
-import { UserService } from '../services/UserService.js';
+import { getDefaultUserService } from '../services/UserService.js';
 
 export const userSchema = z.object({
   id: z.string(),
@@ -12,7 +12,7 @@ export const userListSchema = z.array(userSchema);
 
 export const usersRouter = Router();
 
-const users = new UserService();
+const users = getDefaultUserService();
 
 usersRouter.get('/', async (_req, res) => {
   const all = await users.list();

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,5 +1,5 @@
-import { InMemoryUserDb } from './db.js';
-import { EmailSender } from './emailSender.js';
+import { InMemoryUserDb, type UserDb } from './db.js';
+import { EmailSender, type Emailer } from './emailSender.js';
 
 export interface User {
   id: string;
@@ -9,13 +9,11 @@ export interface User {
 }
 
 /**
- * UserService currently constructs its own collaborators internally.
- * This makes it hard to test and impossible to swap implementations —
- * see issue #5 for the planned refactor to constructor injection.
+ * UserService receives its collaborators via constructor injection so
+ * call sites (and tests) can swap in fakes without monkey-patching.
  */
 export class UserService {
-  private db = new InMemoryUserDb();
-  private email = new EmailSender();
+  constructor(private readonly db: UserDb, private readonly email: Emailer) {}
 
   async authenticate(email: string, password: string): Promise<User | null> {
     const user = await this.db.findByEmail(email);
@@ -37,4 +35,17 @@ export class UserService {
     await this.email.send(email, 'Welcome', `Hi ${name}, your account is ready.`);
     return user;
   }
+}
+
+let defaultInstance: UserService | null = null;
+
+/**
+ * Shared default instance for route modules. Tests should construct
+ * their own UserService with fake collaborators rather than using this.
+ */
+export function getDefaultUserService(): UserService {
+  if (!defaultInstance) {
+    defaultInstance = new UserService(new InMemoryUserDb(), new EmailSender());
+  }
+  return defaultInstance;
 }

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -1,12 +1,19 @@
 import type { User } from './UserService.js';
 
+export interface UserDb {
+  list(): Promise<User[]>;
+  findById(id: string): Promise<User | null>;
+  findByEmail(email: string): Promise<User | null>;
+  create(input: Omit<User, 'id'>): Promise<User>;
+}
+
 const seed: User[] = [
   { id: '1', email: 'ada@example.com', name: 'Ada Lovelace', passwordHash: 'hashed:password' },
   { id: '2', email: 'grace@example.com', name: 'Grace Hopper', passwordHash: 'hashed:password' },
   { id: '3', email: 'alan@example.com', name: 'Alan Turing', passwordHash: 'hashed:password' },
 ];
 
-export class InMemoryUserDb {
+export class InMemoryUserDb implements UserDb {
   private users: User[] = [...seed];
 
   async list(): Promise<User[]> {

--- a/src/services/emailSender.ts
+++ b/src/services/emailSender.ts
@@ -1,4 +1,8 @@
-export class EmailSender {
+export interface Emailer {
+  send(to: string, subject: string, body: string): Promise<void>;
+}
+
+export class EmailSender implements Emailer {
   async send(to: string, subject: string, body: string): Promise<void> {
     console.log(`[email] to=${to} subject=${subject} body=${body.slice(0, 40)}...`);
   }

--- a/tests/userService.spec.ts
+++ b/tests/userService.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { UserService, type User } from '../src/services/UserService.js';
+import type { UserDb } from '../src/services/db.js';
+import type { Emailer } from '../src/services/emailSender.js';
+
+function buildFakeDb(initial: User[] = []): UserDb & { created: User[] } {
+  const users = [...initial];
+  const created: User[] = [];
+  return {
+    created,
+    async list() { return [...users]; },
+    async findById(id) { return users.find((u) => u.id === id) ?? null; },
+    async findByEmail(email) { return users.find((u) => u.email === email) ?? null; },
+    async create(input) {
+      const user: User = { id: String(users.length + 1), ...input };
+      users.push(user);
+      created.push(user);
+      return user;
+    },
+  };
+}
+
+describe('UserService (DI)', () => {
+  it('authenticates against the injected db', async () => {
+    const db = buildFakeDb([
+      { id: '1', email: 'a@x.com', name: 'A', passwordHash: 'hashed:pw' },
+    ]);
+    const email: Emailer = { send: vi.fn() };
+    const svc = new UserService(db, email);
+
+    expect(await svc.authenticate('a@x.com', 'pw')).not.toBeNull();
+    expect(await svc.authenticate('a@x.com', 'wrong')).toBeNull();
+    expect(email.send).not.toHaveBeenCalled();
+  });
+
+  it('calls the injected emailer on invite', async () => {
+    const db = buildFakeDb();
+    const email: Emailer = { send: vi.fn().mockResolvedValue(undefined) };
+    const svc = new UserService(db, email);
+
+    const user = await svc.invite('new@x.com', 'New User');
+
+    expect(user.email).toBe('new@x.com');
+    expect(db.created).toHaveLength(1);
+    expect(email.send).toHaveBeenCalledWith('new@x.com', 'Welcome', expect.any(String));
+  });
+});


### PR DESCRIPTION
Closes #5.

## Design decision
Two reasonable options:

1. Concrete types on the constructor (`constructor(db: InMemoryUserDb, email: EmailSender)`) — simplest, but couples `UserService` to specific implementations.
2. Extracted interfaces on the constructor (`constructor(db: UserDb, email: Emailer)`) — slightly more ceremony, but lets tests pass in fakes and lets callers swap in a real DB / SES client later without touching `UserService`.

Went with **option 2**. The test file shows exactly the payoff — a hand-rolled fake `UserDb` and a `vi.fn()` emailer, no monkey-patching, no container.

## Changes
- `src/services/db.ts` — export `UserDb` interface; `InMemoryUserDb implements UserDb`.
- `src/services/emailSender.ts` — export `Emailer` interface; `EmailSender implements Emailer`.
- `src/services/UserService.ts` — constructor-injected `db` + `email`. Adds a `getDefaultUserService()` factory so route modules keep one shared instance in production without each constructing their own.
- `src/routes/auth.ts`, `src/routes/users.ts` — use the factory.
- `tests/userService.spec.ts` — new unit tests with fake collaborators.

## Verified
- `npm run lint` clean
- `npm test` 4/4 (old login test still green, 2 new unit tests)
