### PR TITLE
fix: remove race condition in login test

### DIFF
--- a/tests/login.spec.ts
+++ b/tests/login.spec.ts
@@ -14,16 +14,10 @@ describe('POST /api/auth/login', () => {
   it('should redirect to dashboard after successful login', async () => {
     const app = createApp();
 
-    // NOTE: this test is intentionally flaky — see issue #2.
-    // It uses a fixed timeout instead of awaiting the network response,
-    // which races with the dashboard data fetch on slower CI runners.
-    const loginPromise = request(app)
+    const res = await request(app)
       .post('/api/auth/login')
       .send({ email: 'ada@example.com', password: 'password' });
 
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    const res = await loginPromise;
     expect(res.status).toBe(200);
     expect(res.body.token).toMatch(/^demo-token-/);
     expect(res.body.user.email).toBe('ada@example.com');


### PR DESCRIPTION
## Summary

Fixes #2 — the flaky `should redirect to dashboard after successful login` test.

### Root cause

The test used a fixed `setTimeout(10ms)` between firing the login request and awaiting its result. On slower CI runners, the auth response hadn't arrived yet, causing an intermittent timeout.

### Fix

Removed the intermediate `setTimeout` and the split `loginPromise` pattern. The test now directly `await`s the supertest request, which is the idiomatic and deterministic approach — no arbitrary sleeps or waits.

### Verification

- Both tests pass locally (`npm test` → 2/2 ✓)
- No sleep/wait calls remain in the test