### PR TITLE
feat: add dark mode toggle to app header

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,3 +1,26 @@
+// --- Theme toggle ---
+(function initThemeToggle() {
+  const toggle = document.getElementById('theme-toggle');
+  if (!toggle) return;
+
+  function currentTheme() {
+    return document.documentElement.getAttribute('data-theme') || 'light';
+  }
+
+  function applyIcon() {
+    toggle.textContent = currentTheme() === 'dark' ? '☀️' : '🌙';
+  }
+
+  applyIcon();
+
+  toggle.addEventListener('click', () => {
+    const next = currentTheme() === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+    applyIcon();
+  });
+})();
+
 const form = document.getElementById('login-form');
 if (form) {
   form.addEventListener('submit', async (e) => {

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -5,6 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Dashboard — Demo App</title>
     <link rel="stylesheet" href="/styles.css" />
+    <script>
+      // Apply saved theme before first paint to prevent FOUC
+      (function(){var t=localStorage.getItem('theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');document.documentElement.setAttribute('data-theme',t)})();
+    </script>
   </head>
   <body>
     <header class="app-header">
@@ -12,6 +16,7 @@
       <nav>
         <a href="/">Home</a>
         <a href="/login.html">Sign out</a>
+        <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode">🌙</button>
       </nav>
     </header>
 

--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Demo App</title>
     <link rel="stylesheet" href="/styles.css" />
+    <script>
+      // Apply saved theme before first paint to prevent FOUC
+      (function(){var t=localStorage.getItem('theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');document.documentElement.setAttribute('data-theme',t)})();
+    </script>
   </head>
   <body>
     <header class="app-header">
@@ -12,6 +16,7 @@
       <nav>
         <a href="/">Home</a>
         <a href="/login.html">Sign in</a>
+        <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode">🌙</button>
       </nav>
     </header>
 

--- a/public/login.html
+++ b/public/login.html
@@ -5,12 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Sign in — Demo App</title>
     <link rel="stylesheet" href="/styles.css" />
+    <script>
+      // Apply saved theme before first paint to prevent FOUC
+      (function(){var t=localStorage.getItem('theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');document.documentElement.setAttribute('data-theme',t)})();
+    </script>
   </head>
   <body>
     <header class="app-header">
       <div class="brand">Demo App</div>
       <nav>
         <a href="/">Home</a>
+        <button class="theme-toggle" id="theme-toggle" aria-label="Toggle dark mode">🌙</button>
       </nav>
     </header>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -7,6 +7,15 @@
   --accent: #0969da;
 }
 
+[data-theme='dark'] {
+  --bg: #0d1117;
+  --fg: #e6edf3;
+  --muted: #8b949e;
+  --surface: #161b22;
+  --border: #30363d;
+  --accent: #58a6ff;
+}
+
 * { box-sizing: border-box; }
 
 html, body {
@@ -62,9 +71,26 @@ button {
 }
 
 .error { color: #cf222e; }
+[data-theme='dark'] .error { color: #f85149; }
 
 code {
   background: var(--surface);
   padding: 2px 6px;
   border-radius: 4px;
+}
+
+.theme-toggle {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--fg);
+  cursor: pointer;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 1rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+}
+.theme-toggle:hover {
+  background: var(--surface);
 }


### PR DESCRIPTION
## Summary

Adds a dark mode toggle button to the app header, addressing #1.

## Changes

- **`public/styles.css`** — Added `[data-theme='dark']` color tokens alongside existing `:root` light tokens, plus `.theme-toggle` button styles
- **`public/index.html`, `dashboard.html`, `login.html`** — Added toggle button in the header nav and an inline `<script>` to apply the saved theme before first paint (prevents FOUC)
- **`public/app.js`** — Added theme toggle click handler that switches `data-theme`, persists to `localStorage`, and updates the button icon (🌙/☀️)

## Acceptance Criteria

- ✅ Theme toggle button visible in the header on all pages
- ✅ Clicking toggles between light and dark themes instantly
- ✅ Theme persists via `localStorage`
- ✅ Respects `prefers-color-scheme` on first visit
- ✅ No FOUC — inline script applies theme before first paint
- ✅ Color tokens are centralized for easy future theme additions

Closes #1