### PR TITLE
feat: Add rate limiting middleware to the public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,36 @@ Sign in with `ada@example.com` / `password`.
 API docs are served at [http://localhost:3000/docs](http://localhost:3000/docs)
 when the dev server is running.
 
+## Rate Limiting
+
+All `/api/*` routes are rate-limited to **100 requests per minute per IP** by default.
+
+**Response headers** on every API response:
+- `X-RateLimit-Limit` – the maximum number of requests in the window
+- `X-RateLimit-Remaining` – requests remaining in the current window
+- `X-RateLimit-Reset` – Unix timestamp (seconds) when the window resets
+
+When the limit is exceeded, the server returns **429 Too Many Requests** with a `Retry-After` header (seconds until the window resets).
+
+**Per-route override:** Mount a separate `createRateLimiter()` instance with custom options on a specific route *before* the global limiter:
+
+```ts
+import { createRateLimiter } from './middleware/rateLimit.js';
+
+// Stricter limit for login: 10 requests/min
+app.use('/api/auth', createRateLimiter({ maxRequests: 10, windowMs: 60_000 }));
+
+// Global default: 100 requests/min
+app.use('/api', createRateLimiter());
+```
+
+**Configuration options** (passed to `createRateLimiter()`):
+
+| Option        | Default  | Description                          |
+|---------------|----------|--------------------------------------|
+| `windowMs`    | `60000`  | Time window in milliseconds          |
+| `maxRequests` | `100`    | Max requests per IP within the window|
+
 ## Layout
 
 ```

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -1,0 +1,74 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export interface RateLimitMetrics {
+  allowed: number;
+  throttled: number;
+}
+
+export interface RateLimitOptions {
+  windowMs: number;
+  maxRequests: number;
+}
+
+interface ClientEntry {
+  count: number;
+  resetTime: number;
+}
+
+const DEFAULT_OPTIONS: RateLimitOptions = {
+  windowMs: 60_000,
+  maxRequests: 100,
+};
+
+/**
+ * Creates a rate-limiting middleware that tracks requests per IP.
+ * Returns 429 with Retry-After header when the limit is exceeded.
+ */
+export function createRateLimiter(
+  options: Partial<RateLimitOptions> = {},
+): RequestHandler & { metrics: RateLimitMetrics; reset: () => void } {
+  const { windowMs, maxRequests } = { ...DEFAULT_OPTIONS, ...options };
+  const clients = new Map<string, ClientEntry>();
+  const metrics: RateLimitMetrics = { allowed: 0, throttled: 0 };
+
+  function getClientKey(req: Request): string {
+    return req.ip ?? req.socket.remoteAddress ?? 'unknown';
+  }
+
+  const middleware = ((req: Request, res: Response, next: NextFunction) => {
+    const now = Date.now();
+    const key = getClientKey(req);
+    let entry = clients.get(key);
+
+    if (!entry || now >= entry.resetTime) {
+      entry = { count: 0, resetTime: now + windowMs };
+      clients.set(key, entry);
+    }
+
+    entry.count++;
+
+    // Set rate limit headers on every response
+    res.setHeader('X-RateLimit-Limit', maxRequests);
+    res.setHeader('X-RateLimit-Remaining', Math.max(0, maxRequests - entry.count));
+    res.setHeader('X-RateLimit-Reset', Math.ceil(entry.resetTime / 1000));
+
+    if (entry.count > maxRequests) {
+      metrics.throttled++;
+      const retryAfterSec = Math.ceil((entry.resetTime - now) / 1000);
+      res.setHeader('Retry-After', retryAfterSec);
+      return res.status(429).json({ error: 'Too Many Requests' });
+    }
+
+    metrics.allowed++;
+    next();
+  }) as RequestHandler & { metrics: RateLimitMetrics; reset: () => void };
+
+  middleware.metrics = metrics;
+  middleware.reset = () => {
+    clients.clear();
+    metrics.allowed = 0;
+    metrics.throttled = 0;
+  };
+
+  return middleware;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import swaggerUi from 'swagger-ui-express';
 import { authRouter } from './routes/auth.js';
 import { usersRouter } from './routes/users.js';
 import { generateSpec } from './openapi.js';
+import { createRateLimiter } from './middleware/rateLimit.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -13,6 +14,10 @@ export function createApp() {
   const app = express();
   app.use(cors());
   app.use(express.json());
+
+  // Rate limiting: 100 requests/min per IP on all /api/* routes
+  const apiLimiter = createRateLimiter();
+  app.use('/api', apiLimiter);
 
   app.use('/api/auth', authRouter);
   app.use('/api/users', usersRouter);

--- a/tests/rateLimit.spec.ts
+++ b/tests/rateLimit.spec.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { createRateLimiter } from '../src/middleware/rateLimit.js';
+
+function buildApp(options?: Parameters<typeof createRateLimiter>[0]) {
+  const app = express();
+  const limiter = createRateLimiter(options);
+  app.use('/api', limiter);
+  app.get('/api/test', (_req, res) => res.json({ ok: true }));
+  app.get('/api/other', (_req, res) => res.json({ route: 'other' }));
+  app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+  return { app, limiter };
+}
+
+describe('Rate limiting middleware', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('allows requests under the limit', async () => {
+    const { app } = buildApp({ maxRequests: 5, windowMs: 60_000 });
+
+    const res = await request(app).get('/api/test');
+    expect(res.status).toBe(200);
+    expect(res.headers['x-ratelimit-limit']).toBe('5');
+    expect(res.headers['x-ratelimit-remaining']).toBe('4');
+  });
+
+  it('returns 429 when limit is exceeded', async () => {
+    const { app } = buildApp({ maxRequests: 3, windowMs: 60_000 });
+
+    for (let i = 0; i < 3; i++) {
+      const res = await request(app).get('/api/test');
+      expect(res.status).toBe(200);
+    }
+
+    const blocked = await request(app).get('/api/test');
+    expect(blocked.status).toBe(429);
+    expect(blocked.body.error).toBe('Too Many Requests');
+    expect(blocked.headers['retry-after']).toBeDefined();
+  });
+
+  it('includes Retry-After header on 429 responses', async () => {
+    const { app } = buildApp({ maxRequests: 1, windowMs: 30_000 });
+
+    await request(app).get('/api/test');
+    const blocked = await request(app).get('/api/test');
+
+    expect(blocked.status).toBe(429);
+    const retryAfter = Number(blocked.headers['retry-after']);
+    expect(retryAfter).toBeGreaterThan(0);
+    expect(retryAfter).toBeLessThanOrEqual(30);
+  });
+
+  it('resets the window after the time period', async () => {
+    const { app } = buildApp({ maxRequests: 2, windowMs: 10_000 });
+
+    await request(app).get('/api/test');
+    await request(app).get('/api/test');
+
+    const blocked = await request(app).get('/api/test');
+    expect(blocked.status).toBe(429);
+
+    // Advance time past the window
+    vi.advanceTimersByTime(11_000);
+
+    const afterReset = await request(app).get('/api/test');
+    expect(afterReset.status).toBe(200);
+    expect(afterReset.headers['x-ratelimit-remaining']).toBe('1');
+  });
+
+  it('does not rate-limit non-API routes', async () => {
+    const { app } = buildApp({ maxRequests: 1, windowMs: 60_000 });
+
+    await request(app).get('/api/test');
+    const blocked = await request(app).get('/api/test');
+    expect(blocked.status).toBe(429);
+
+    // /health is outside /api, so not rate-limited
+    const healthRes = await request(app).get('/health');
+    expect(healthRes.status).toBe(200);
+  });
+
+  it('supports per-route override via separate limiter instance', async () => {
+    const app = express();
+    const globalLimiter = createRateLimiter({ maxRequests: 10, windowMs: 60_000 });
+    const strictLimiter = createRateLimiter({ maxRequests: 2, windowMs: 60_000 });
+
+    app.use('/api/strict', strictLimiter);
+    app.use('/api', globalLimiter);
+    app.get('/api/test', (_req, res) => res.json({ ok: true }));
+    app.get('/api/strict/action', (_req, res) => res.json({ ok: true }));
+
+    // Strict route allows only 2
+    await request(app).get('/api/strict/action');
+    await request(app).get('/api/strict/action');
+    const strictBlocked = await request(app).get('/api/strict/action');
+    expect(strictBlocked.status).toBe(429);
+
+    // Global route still works
+    const globalRes = await request(app).get('/api/test');
+    expect(globalRes.status).toBe(200);
+  });
+
+  it('tracks allowed and throttled metrics', async () => {
+    const { app, limiter } = buildApp({ maxRequests: 2, windowMs: 60_000 });
+
+    await request(app).get('/api/test');
+    await request(app).get('/api/test');
+    await request(app).get('/api/test');
+
+    expect(limiter.metrics.allowed).toBe(2);
+    expect(limiter.metrics.throttled).toBe(1);
+  });
+
+  it('uses default options (100 req/min) when none provided', async () => {
+    const { app } = buildApp();
+
+    const res = await request(app).get('/api/test');
+    expect(res.status).toBe(200);
+    expect(res.headers['x-ratelimit-limit']).toBe('100');
+    expect(res.headers['x-ratelimit-remaining']).toBe('99');
+  });
+});


### PR DESCRIPTION
## Summary

Adds rate limiting middleware to all `/api/*` routes, addressing issue #3.

## Changes

- **`src/middleware/rateLimit.ts`** — New middleware with configurable window and max requests per IP
- **`src/server.ts`** — Wire the rate limiter globally on `/api/*`
- **`tests/rateLimit.spec.ts`** — 8 unit tests covering all acceptance criteria
- **`README.md`** — Configuration documentation

## Behaviour

| Feature | Detail |
|---------|--------|
| Default limit | 100 requests / minute / IP |
| Per-route override | Mount a separate `createRateLimiter()` before the global one |
| 429 response | Returns `{ error: "Too Many Requests" }` with `Retry-After` header |
| Rate limit headers | `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` |
| Metrics | `limiter.metrics.allowed` / `limiter.metrics.throttled` |

## Test results

All 10 tests pass (8 new rate limiter tests + 2 existing login tests).

Closes #3