### PR TITLE
refactor: use constructor-based dependency injection in UserService

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { z } from 'zod';
-import { UserService } from '../services/UserService.js';
+import type { UserService } from '../services/UserService.js';
 
 export const loginSchema = z.object({
   email: z.string().email(),
@@ -16,23 +16,25 @@ export const loginResponseSchema = z.object({
   }),
 });
 
-export const authRouter = Router();
+export function createAuthRouter(users: UserService) {
+  const router = Router();
 
-const users = new UserService();
+  router.post('/login', async (req, res) => {
+    const parsed = loginSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: 'Invalid request body' });
+    }
 
-authRouter.post('/login', async (req, res) => {
-  const parsed = loginSchema.safeParse(req.body);
-  if (!parsed.success) {
-    return res.status(400).json({ error: 'Invalid request body' });
-  }
+    const user = await users.authenticate(parsed.data.email, parsed.data.password);
+    if (!user) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
 
-  const user = await users.authenticate(parsed.data.email, parsed.data.password);
-  if (!user) {
-    return res.status(401).json({ error: 'Invalid credentials' });
-  }
-
-  res.json({
-    token: `demo-token-${user.id}`,
-    user: { id: user.id, email: user.email, name: user.name },
+    res.json({
+      token: `demo-token-${user.id}`,
+      user: { id: user.id, email: user.email, name: user.name },
+    });
   });
-});
+
+  return router;
+}

--- a/src/routes/users.ts
+++ b/src/routes/users.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { z } from 'zod';
-import { UserService } from '../services/UserService.js';
+import type { UserService } from '../services/UserService.js';
 
 export const userSchema = z.object({
   id: z.string(),
@@ -10,17 +10,19 @@ export const userSchema = z.object({
 
 export const userListSchema = z.array(userSchema);
 
-export const usersRouter = Router();
+export function createUsersRouter(users: UserService) {
+  const router = Router();
 
-const users = new UserService();
+  router.get('/', async (_req, res) => {
+    const all = await users.list();
+    res.json(all.map((u) => ({ id: u.id, email: u.email, name: u.name })));
+  });
 
-usersRouter.get('/', async (_req, res) => {
-  const all = await users.list();
-  res.json(all.map((u) => ({ id: u.id, email: u.email, name: u.name })));
-});
+  router.get('/:id', async (req, res) => {
+    const user = await users.findById(req.params.id);
+    if (!user) return res.status(404).json({ error: 'User not found' });
+    res.json({ id: user.id, email: user.email, name: user.name });
+  });
 
-usersRouter.get('/:id', async (req, res) => {
-  const user = await users.findById(req.params.id);
-  if (!user) return res.status(404).json({ error: 'User not found' });
-  res.json({ id: user.id, email: user.email, name: user.name });
-});
+  return router;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,14 +3,21 @@ import cors from 'cors';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import swaggerUi from 'swagger-ui-express';
-import { authRouter } from './routes/auth.js';
-import { usersRouter } from './routes/users.js';
+import { createAuthRouter } from './routes/auth.js';
+import { createUsersRouter } from './routes/users.js';
 import { generateSpec } from './openapi.js';
 import { createRateLimiter } from './middleware/rateLimit.js';
+import { UserService } from './services/UserService.js';
+import { InMemoryUserDb } from './services/db.js';
+import { EmailSender } from './services/emailSender.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export function createApp() {
+  const db = new InMemoryUserDb();
+  const email = new EmailSender();
+  const userService = new UserService(db, email);
+
   const app = express();
   app.use(cors());
   app.use(express.json());
@@ -19,8 +26,8 @@ export function createApp() {
   const apiLimiter = createRateLimiter();
   app.use('/api', apiLimiter);
 
-  app.use('/api/auth', authRouter);
-  app.use('/api/users', usersRouter);
+  app.use('/api/auth', createAuthRouter(userService));
+  app.use('/api/users', createUsersRouter(userService));
 
   app.get('/api/health', (_req, res) => {
     res.json({ status: 'ok' });

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,6 +1,3 @@
-import { InMemoryUserDb } from './db.js';
-import { EmailSender } from './emailSender.js';
-
 export interface User {
   id: string;
   email: string;
@@ -8,14 +5,22 @@ export interface User {
   passwordHash: string;
 }
 
-/**
- * UserService currently constructs its own collaborators internally.
- * This makes it hard to test and impossible to swap implementations —
- * see issue #5 for the planned refactor to constructor injection.
- */
+export interface UserDb {
+  list(): Promise<User[]>;
+  findById(id: string): Promise<User | null>;
+  findByEmail(email: string): Promise<User | null>;
+  create(input: Omit<User, 'id'>): Promise<User>;
+}
+
+export interface EmailService {
+  send(to: string, subject: string, body: string): Promise<void>;
+}
+
 export class UserService {
-  private db = new InMemoryUserDb();
-  private email = new EmailSender();
+  constructor(
+    private db: UserDb,
+    private email: EmailService,
+  ) {}
 
   async authenticate(email: string, password: string): Promise<User | null> {
     const user = await this.db.findByEmail(email);

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -1,4 +1,4 @@
-import type { User } from './UserService.js';
+import type { User, UserDb } from './UserService.js';
 
 const seed: User[] = [
   { id: '1', email: 'ada@example.com', name: 'Ada Lovelace', passwordHash: 'hashed:password' },
@@ -6,7 +6,7 @@ const seed: User[] = [
   { id: '3', email: 'alan@example.com', name: 'Alan Turing', passwordHash: 'hashed:password' },
 ];
 
-export class InMemoryUserDb {
+export class InMemoryUserDb implements UserDb {
   private users: User[] = [...seed];
 
   async list(): Promise<User[]> {

--- a/src/services/emailSender.ts
+++ b/src/services/emailSender.ts
@@ -1,4 +1,6 @@
-export class EmailSender {
+import type { EmailService } from './UserService.js';
+
+export class EmailSender implements EmailService {
   async send(to: string, subject: string, body: string): Promise<void> {
     console.log(`[email] to=${to} subject=${subject} body=${body.slice(0, 40)}...`);
   }

--- a/tests/UserService.spec.ts
+++ b/tests/UserService.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { UserService } from '../src/services/UserService.js';
+import type { UserDb, EmailService, User } from '../src/services/UserService.js';
+
+class FakeUserDb implements UserDb {
+  private users: User[] = [
+    { id: '1', email: 'ada@example.com', name: 'Ada Lovelace', passwordHash: 'hashed:password' },
+  ];
+
+  async list() {
+    return [...this.users];
+  }
+  async findById(id: string) {
+    return this.users.find((u) => u.id === id) ?? null;
+  }
+  async findByEmail(email: string) {
+    return this.users.find((u) => u.email === email) ?? null;
+  }
+  async create(input: Omit<User, 'id'>) {
+    const user: User = { id: String(this.users.length + 1), ...input };
+    this.users.push(user);
+    return user;
+  }
+}
+
+class FakeEmailService implements EmailService {
+  sent: { to: string; subject: string; body: string }[] = [];
+
+  async send(to: string, subject: string, body: string) {
+    this.sent.push({ to, subject, body });
+  }
+}
+
+describe('UserService', () => {
+  function setup() {
+    const db = new FakeUserDb();
+    const email = new FakeEmailService();
+    const service = new UserService(db, email);
+    return { db, email, service };
+  }
+
+  describe('authenticate', () => {
+    it('returns user for valid credentials', async () => {
+      const { service } = setup();
+      const user = await service.authenticate('ada@example.com', 'password');
+      expect(user).not.toBeNull();
+      expect(user!.email).toBe('ada@example.com');
+    });
+
+    it('returns null for wrong password', async () => {
+      const { service } = setup();
+      const user = await service.authenticate('ada@example.com', 'wrong');
+      expect(user).toBeNull();
+    });
+
+    it('returns null for unknown email', async () => {
+      const { service } = setup();
+      const user = await service.authenticate('unknown@example.com', 'password');
+      expect(user).toBeNull();
+    });
+  });
+
+  describe('list', () => {
+    it('returns all users', async () => {
+      const { service } = setup();
+      const users = await service.list();
+      expect(users).toHaveLength(1);
+      expect(users[0].email).toBe('ada@example.com');
+    });
+  });
+
+  describe('findById', () => {
+    it('returns user by id', async () => {
+      const { service } = setup();
+      const user = await service.findById('1');
+      expect(user).not.toBeNull();
+      expect(user!.name).toBe('Ada Lovelace');
+    });
+
+    it('returns null for missing id', async () => {
+      const { service } = setup();
+      const user = await service.findById('999');
+      expect(user).toBeNull();
+    });
+  });
+
+  describe('invite', () => {
+    it('creates user and sends welcome email', async () => {
+      const { service, email } = setup();
+      const user = await service.invite('new@example.com', 'New User');
+
+      expect(user.email).toBe('new@example.com');
+      expect(user.name).toBe('New User');
+      expect(email.sent).toHaveLength(1);
+      expect(email.sent[0].to).toBe('new@example.com');
+      expect(email.sent[0].subject).toBe('Welcome');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Refactors `UserService` to use constructor-based dependency injection instead of internally constructing its own collaborators.

## Changes

- **Extract interfaces** `UserDb` and `EmailService` in `UserService.ts`
- **Constructor injection**: `UserService` now receives `db` and `email` via constructor
- **Route factories**: `auth.ts` and `users.ts` export `createAuthRouter` / `createUsersRouter` that accept a `UserService`
- **Wiring in `server.ts`**: `createApp()` builds and injects all dependencies
- **New test file** `tests/UserService.spec.ts` with 7 tests using in-memory fakes (no network mocks)

## Acceptance criteria (from issue)

- ✅ `UserService` takes its dependencies via the constructor
- ✅ All existing call sites updated
- ✅ Tests use in-memory fakes instead of network mocks
- ✅ No behavior change in production wiring

All 9 tests pass, TypeScript compiles clean.

Closes #5