### PR TITLE
Add /api/version endpoint

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,11 +1,16 @@
 import express from 'express';
 import cors from 'cors';
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { authRouter } from './routes/auth.js';
 import { usersRouter } from './routes/users.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const pkg = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../package.json'), 'utf-8'),
+) as { version: string };
 
 export function createApp() {
   const app = express();
@@ -17,6 +22,10 @@ export function createApp() {
 
   app.get('/api/health', (_req, res) => {
     res.json({ status: 'ok' });
+  });
+
+  app.get('/api/version', (_req, res) => {
+    res.json({ version: pkg.version });
   });
 
   const publicDir = path.resolve(__dirname, '../public');

--- a/tests/version.spec.ts
+++ b/tests/version.spec.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { createApp } from '../src/server.js';
+
+describe('GET /api/version', () => {
+  it('returns the app version', async () => {
+    const app = createApp();
+    const res = await request(app).get('/api/version');
+    expect(res.status).toBe(200);
+    expect(res.body.version).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});


### PR DESCRIPTION
Adds a tiny read-only endpoint so clients and ops can confirm which build of the demo app is running without shelling into the host or guessing from headers.

## Approach

- `src/server.ts` reads `package.json` once at startup and registers `GET /api/version`, which responds with `{ "version": "<semver>" }`.
- `tests/version.spec.ts` covers the new route with supertest, asserting a 200 and a semver-shaped body.

The version is read at startup (not per request) so the handler stays allocation-free, and the path lives alongside `/api/health` to keep the "ops" routes grouped.

## Verification

`npm test` - 3 passed (login x2, version x1).